### PR TITLE
Reorganizing namespaces and fixing errors in CUDA functions: misunder…

### DIFF
--- a/CUDA_Noise.vcxproj
+++ b/CUDA_Noise.vcxproj
@@ -144,6 +144,7 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     <ClInclude Include="cpp\modules\modifiers\Abs.h" />
     <ClInclude Include="cpp\modules\modifiers\Add.h" />
     <ClInclude Include="cpp\modules\modifiers\Curve.h" />
+    <ClInclude Include="cpp\modules\modifiers\ScaleBias.h" />
     <ClInclude Include="cpp\modules\modifiers\Select.h" />
     <ClInclude Include="cpp\modules\modifiers\Turbulence.h" />
     <ClInclude Include="cuda\cuda_assert.h" />
@@ -173,8 +174,10 @@ copy "$(CudaToolkitBinDir)\cudart*.dll" "$(OutDir)"</Command>
     <ClCompile Include="cpp\modules\generators\FBM.cpp" />
     <ClCompile Include="cpp\modules\generators\RidgedMulti.cpp" />
     <ClCompile Include="cpp\modules\generators\Voronoi.cpp" />
+    <ClCompile Include="cpp\modules\modifiers\Abs.cpp" />
     <ClCompile Include="cpp\modules\modifiers\Add.cpp" />
     <ClCompile Include="cpp\modules\modifiers\Curve.cpp" />
+    <ClCompile Include="cpp\modules\modifiers\ScaleBias.cpp" />
     <ClCompile Include="cpp\modules\modifiers\Select.cpp" />
     <ClCompile Include="cpp\modules\modifiers\Turbulence.cpp" />
   </ItemGroup>

--- a/common/CUDA_Include.h
+++ b/common/CUDA_Include.h
@@ -19,37 +19,4 @@
 #include <device_functions.h>
 #include "../cuda/cuda_assert.h"
 
-typedef unsigned int uint;
-typedef unsigned char uchar;
-
-enum noise_t {
-	PERLIN,
-	SIMPLEX,
-};
-
-// Type of distance function to use in voronoi generation
-enum voronoi_distance_t {
-	MANHATTAN,
-	EUCLIDEAN,
-	CELLULAR,
-};
-
-// Type of value to get from a voronoi function, and then store in the output texture.
-enum voronoi_return_t {
-	CELL_VALUE, // Get cell coord/val. Analagous to value noise.
-	NOISE_LOOKUP, // Use coords to get a noise value
-	DISTANCE, // Get distance to node.
-};
-
-enum noise_quality {
-	FAST,
-	STANDARD,
-	HIGH,
-};
-
-typedef struct alignas(sizeof(float)) ControlPoint {
-	float InputVal, OutputVal;
-	ControlPoint(float in, float out) : InputVal(in), OutputVal(out) {}
-} ControlPoint;
-
 #endif // !CUDA_INCLUDE_H

--- a/common/CommonInclude.h
+++ b/common/CommonInclude.h
@@ -24,5 +24,41 @@
 #include <cstdint>
 #include <memory>
 
+namespace cnoise {
+
+	enum noise_t {
+		PERLIN,
+		SIMPLEX,
+	};
+
+	// Type of distance function to use in voronoi generation
+	enum voronoi_distance_t {
+		MANHATTAN,
+		EUCLIDEAN,
+		CELLULAR,
+	};
+
+	// Type of value to get from a voronoi function, and then store in the output texture.
+	enum voronoi_return_t {
+		CELL_VALUE, // Get cell coord/val. Analagous to value noise.
+		NOISE_LOOKUP, // Use coords to get a noise value
+		DISTANCE, // Get distance to node.
+	};
+
+	enum noise_quality {
+		FAST,
+		STANDARD,
+		HIGH,
+	};
+
+	typedef unsigned int uint;
+	typedef unsigned char uchar;
+
+	typedef struct alignas(sizeof(float)) ControlPoint {
+		float InputVal, OutputVal;
+		ControlPoint(float in, float out) : InputVal(in), OutputVal(out) {}
+	} ControlPoint;
+
+}
 
 #endif // !COMMON_INCLUDE_H

--- a/common/Constants.h
+++ b/common/Constants.h
@@ -12,14 +12,10 @@
 
 // Noise types.
 
-namespace noise {
-	namespace module {
+namespace cnoise {
+	namespace generators {
 
-		// Types of base noise available 
-		enum class NoiseType {
-			PERLIN,
-			SIMPLEX,
-		};
+		
 
 	}
 }

--- a/cpp/image/Image.cpp
+++ b/cpp/image/Image.cpp
@@ -2,205 +2,211 @@
 #include "lodepng\lodepng.h"
 #include "Image.h"
 #include <algorithm>
+namespace cnoise {
 
-inline void unpack_16bit(int16_t in, uint8_t* dest) {
-	dest[0] = static_cast<uint8_t>(in & 0x00ff);
-	dest[1] = static_cast<uint8_t>((in & 0xff00) >> 8);
-	return;
-}
-
-inline void unpack_32bit(int32_t integer, uint8_t* dest) {
-	dest[0] = static_cast<uint8_t>((integer & 0x000000ff));
-	dest[1] = static_cast<uint8_t>((integer & 0x0000ff00) >> 8);
-	dest[2] = static_cast<uint8_t>((integer & 0x00ff0000) >> 16);
-	dest[3] = static_cast<uint8_t>((integer & 0xff000000) >> 24);
-	return;
-}
-
-inline void unpack_float(float in, uint8_t* dest) {
-	uint8_t* bytes = reinterpret_cast<uint8_t*>(&in);
-	dest[0] = *bytes++;
-	dest[1] = *bytes++;
-	dest[2] = *bytes++;
-	dest[3] = *bytes++;
-	return;
-}
-
-template<typename T>
-inline auto convertRawData(const std::vector<float>& raw_data)->std::vector<T> {
-	// We need to scale the data to fit in the range of the desired return type.
-	T t_min, t_max;
-	t_min = std::numeric_limits<T>::min();
-	t_max = std::numeric_limits<T>::max();
-	// Declare result vector so we can use std::transform shortly.
-	std::vector<T> result;
-	result.reserve(raw_data.size());
-	// Get min/max values from raw data
-	auto min_max = std::minmax_element(raw_data.begin(), raw_data.end());
-	float max = *min_max.second;
-	float min = *min_max.first;
-	// Conversion lambda expression
-	auto convert = [min, max, t_min, t_max](const float& val)->T {
-		float result = ((val - min) / (min - max) * static_cast<float>(t_max - t_min)) + t_min;
-		return result;
-	};
-	// Convert data
-	std::transform(raw_data.begin(), raw_data.end(), std::back_inserter(result), convert);
-	return result;
-}
-
-template<typename T>
-inline auto convertRawData_Ranged(const std::vector<float>& raw_data, const float& lower_bound, const float& upper_bound)->std::vector<T> {
-	// Declare result vector so we can use std::transform shortly.
-	std::vector<T> result;
-	result.reserve(raw_data.size());
-	// Get min/max values from raw data
-	auto min_max = std::minmax_element(raw_data.begin(), raw_data.end());
-	float max = *min_max.second;
-	float min = *min_max.first;
-	// Conversion lambda expression
-	auto convert = [min, max, lower_bound, upper_bound](const float& val)->T {
-		float result = (val - min) / (min - max); // Normalize val into 0.0 - 1.0 range.
-		result *= upper_bound;
-		result += lower_bound;
-		return static_cast<T>(result);
-	};
-	// Convert data
-	std::transform(raw_data.begin(), raw_data.end(), std::back_inserter(result), convert);
-	return result;
-}
-
-ImageWriter::ImageWriter(int _width, int _height) : width(_width), height(_height) {
-	// Setup destination for raw data.
-	rawData.resize(width * height);
-}
-
-void ImageWriter::FreeMemory(){
-	rawData.clear();
-	rawData.shrink_to_fit();
-	pixelData.clear();
-	pixelData.shrink_to_fit();
-}
-
-void ImageWriter::WriteBMP(const char * filename){
-	uint8_t d[4];
-	std::ofstream os;
-	os.open(filename);
-	if (os.fail() || os.bad()) {
-		throw;
-	}
-
-	// Build header.
-	os.write("BM", 2);
-
-}
-
-void ImageWriter::WritePNG(const char * filename, int compression_level){
-	std::vector<unsigned char> tmpBuffer = convertRawData<unsigned char>(rawData);
-	// Copy values over to pixelData, for a grayscale image.
-	pixelData.resize(4 * tmpBuffer.size());
-	for (size_t y = 0; y < height; ++y) {
-		for (size_t x = 0; x < width; ++x) {
-			size_t idx = 4 * width * y + 4 * x;
-			pixelData[idx + 0] = tmpBuffer[width * y + x];
-			pixelData[idx + 1] = tmpBuffer[width * y + x];
-			pixelData[idx + 2] = tmpBuffer[width * y + x];
-			pixelData[idx + 3] = 255;
-		}
-	}
-	if (compression_level == 0) {
-		// Saves uncompressed image using "pixelData" to "filename"
-		unsigned err;
-		err = lodepng::encode(filename, &pixelData[0], width, height);
-		if (!err) {
+	namespace img {
+		inline void unpack_16bit(int16_t in, uint8_t* dest) {
+			dest[0] = static_cast<uint8_t>(in & 0x00ff);
+			dest[1] = static_cast<uint8_t>((in & 0xff00) >> 8);
 			return;
 		}
-		else {
-			std::cout << "Error encoding image, code " << err << ": " << lodepng_error_text(err) << std::endl;
+
+		inline void unpack_32bit(int32_t integer, uint8_t* dest) {
+			dest[0] = static_cast<uint8_t>((integer & 0x000000ff));
+			dest[1] = static_cast<uint8_t>((integer & 0x0000ff00) >> 8);
+			dest[2] = static_cast<uint8_t>((integer & 0x00ff0000) >> 16);
+			dest[3] = static_cast<uint8_t>((integer & 0xff000000) >> 24);
+			return;
 		}
+
+		inline void unpack_float(float in, uint8_t* dest) {
+			uint8_t* bytes = reinterpret_cast<uint8_t*>(&in);
+			dest[0] = *bytes++;
+			dest[1] = *bytes++;
+			dest[2] = *bytes++;
+			dest[3] = *bytes++;
+			return;
+		}
+
+		template<typename T>
+		inline auto convertRawData(const std::vector<float>& raw_data)->std::vector<T> {
+			// We need to scale the data to fit in the range of the desired return type.
+			T t_min, t_max;
+			t_min = std::numeric_limits<T>::min();
+			t_max = std::numeric_limits<T>::max();
+			// Declare result vector so we can use std::transform shortly.
+			std::vector<T> result;
+			result.reserve(raw_data.size());
+			// Get min/max values from raw data
+			auto min_max = std::minmax_element(raw_data.begin(), raw_data.end());
+			float max = *min_max.second;
+			float min = *min_max.first;
+			// Conversion lambda expression
+			auto convert = [min, max, t_min, t_max](const float& val)->T {
+				float result = ((val - min) / (min - max) * static_cast<float>(t_max - t_min)) + t_min;
+				return result;
+			};
+			// Convert data
+			std::transform(raw_data.begin(), raw_data.end(), std::back_inserter(result), convert);
+			return result;
+		}
+
+		template<typename T>
+		inline auto convertRawData_Ranged(const std::vector<float>& raw_data, const float& lower_bound, const float& upper_bound)->std::vector<T> {
+			// Declare result vector so we can use std::transform shortly.
+			std::vector<T> result;
+			result.reserve(raw_data.size());
+			// Get min/max values from raw data
+			auto min_max = std::minmax_element(raw_data.begin(), raw_data.end());
+			float max = *min_max.second;
+			float min = *min_max.first;
+			// Conversion lambda expression
+			auto convert = [min, max, lower_bound, upper_bound](const float& val)->T {
+				float result = (val - min) / (min - max); // Normalize val into 0.0 - 1.0 range.
+				result *= upper_bound;
+				result += lower_bound;
+				return static_cast<T>(result);
+			};
+			// Convert data
+			std::transform(raw_data.begin(), raw_data.end(), std::back_inserter(result), convert);
+			return result;
+		}
+
+		ImageWriter::ImageWriter(int _width, int _height) : width(_width), height(_height) {
+			// Setup destination for raw data.
+			rawData.resize(width * height);
+		}
+
+		void ImageWriter::FreeMemory() {
+			rawData.clear();
+			rawData.shrink_to_fit();
+			pixelData.clear();
+			pixelData.shrink_to_fit();
+		}
+
+		void ImageWriter::WriteBMP(const char * filename) {
+			uint8_t d[4];
+			std::ofstream os;
+			os.open(filename);
+			if (os.fail() || os.bad()) {
+				throw;
+			}
+
+			// Build header.
+			os.write("BM", 2);
+
+		}
+
+		void ImageWriter::WritePNG(const char * filename, int compression_level) {
+			std::vector<unsigned char> tmpBuffer = convertRawData<unsigned char>(rawData);
+			// Copy values over to pixelData, for a grayscale image.
+			pixelData.resize(4 * tmpBuffer.size());
+			for (size_t y = 0; y < height; ++y) {
+				for (size_t x = 0; x < width; ++x) {
+					size_t idx = 4 * width * y + 4 * x;
+					pixelData[idx + 0] = tmpBuffer[width * y + x];
+					pixelData[idx + 1] = tmpBuffer[width * y + x];
+					pixelData[idx + 2] = tmpBuffer[width * y + x];
+					pixelData[idx + 3] = 255;
+				}
+			}
+			if (compression_level == 0) {
+				// Saves uncompressed image using "pixelData" to "filename"
+				unsigned err;
+				err = lodepng::encode(filename, &pixelData[0], width, height);
+				if (!err) {
+					return;
+				}
+				else {
+					std::cout << "Error encoding image, code " << err << ": " << lodepng_error_text(err) << std::endl;
+				}
+			}
+			else {
+				// TODO: Implement compression. Need to study parameters of LodePNG more. See: https://raw.githubusercontent.com/lvandeve/lodepng/master/examples/example_optimize_png.cpp
+			}
+			pixelData.clear();
+			pixelData.shrink_to_fit();
+		}
+
+		void ImageWriter::WriteTER(const char* filename) {
+
+			// Output data size.
+			size_t byte_width = width * sizeof(int16_t);
+			size_t total_size = byte_width * height;
+
+			// Buffer a line of data at a time.
+			std::vector<uint8_t> lineBuffer;
+			lineBuffer.reserve(byte_width);
+
+			// Open output file stream
+			std::ofstream out;
+			out.clear();
+
+			// Oopen output file in binary mode
+			out.open(filename, std::ios::out | std::ios::binary);
+
+			// Build header.
+			// height_scale - 0.50f in divisor means 0.25m between sampling points.
+			int16_t height_scale = static_cast<int16_t>(floorf(32768.0f / 30.0f));
+			// Buffer used for unpacking various types into correct format for writing to stream.
+			uint8_t buffer[4];
+			out.write("TERRAGENTERRAIN ", 16); // First element of header.
+			// Write terrain size.
+			out.write("SIZE", 4);
+			unpack_16bit(static_cast<int16_t>(std::min(width, height) - 1), buffer);
+			out.write(reinterpret_cast<char*>(buffer), 2);
+			out.write("\0\0", 2);
+			// X dim.
+			out.write("XPTS", 4);
+			unpack_16bit(static_cast<int16_t>(width), buffer);
+			out.write(reinterpret_cast<char*>(buffer), 2);
+			out.write("\0\0", 2);
+			// Y dim
+			out.write("YPTS", 4);
+			unpack_16bit(static_cast<int16_t>(height), buffer);
+			out.write(reinterpret_cast<char*>(buffer), 2);
+			out.write("\0\0", 2);
+			// Write scale.
+			out.write("SCAL", 4);
+			// point-sampling scale is XYZ quantity, write same value three times.
+			unpack_float(15.0f, buffer);
+			out.write(reinterpret_cast<char*>(buffer), 4);
+			out.write(reinterpret_cast<char*>(buffer), 4);
+			out.write(reinterpret_cast<char*>(buffer), 4);
+			// Write height scale
+			out.write("ALTW", 4);
+			unpack_16bit(height_scale, buffer);
+			out.write(reinterpret_cast<char*>(buffer), 4);
+			out.write("\0\0", 2);
+			if (out.fail() || out.bad()) {
+				throw;
+			}
+
+			// Build and write each horizontal line to the file.
+			std::vector<int16_t> height_values = convertRawData_Ranged<int16_t>(rawData, 0.0f, 1000.0f);
+			for (size_t i = 0; i < height_values.size(); ++i) {
+				uint8_t buffer[2];
+				unpack_16bit(height_values[i], buffer);
+				out.write(reinterpret_cast<char*>(buffer), 2);
+			}
+
+			out.write("EOF", 4);
+			// Close output file.
+			out.close();
+		}
+
+		void ImageWriter::SetRawData(const std::vector<float>& raw) {
+			rawData = raw;
+		}
+
+		std::vector<float> ImageWriter::GetRawData() const {
+			return rawData;
+		}
+
+		void ImageWriter::WriteBMP_Header(std::ofstream & output_stream) const {
+			// TODO: Implement this. Need to do some more checks on insuring 4-byte alignment and correct sizing, somehow.
+		}
+
+
 	}
-	else {
-		// TODO: Implement compression. Need to study parameters of LodePNG more. See: https://raw.githubusercontent.com/lvandeve/lodepng/master/examples/example_optimize_png.cpp
-	}
-	pixelData.clear();
-	pixelData.shrink_to_fit();
-}
-
-void ImageWriter::WriteTER(const char* filename) {
-
-	// Output data size.
-	size_t byte_width = width * sizeof(int16_t);
-	size_t total_size = byte_width * height;
-
-	// Buffer a line of data at a time.
-	std::vector<uint8_t> lineBuffer;
-	lineBuffer.reserve(byte_width);
-
-	// Open output file stream
-	std::ofstream out;
-	out.clear();
-
-	// Oopen output file in binary mode
-	out.open(filename, std::ios::out | std::ios::binary);
-
-	// Build header.
-	// height_scale - 0.50f in divisor means 0.25m between sampling points.
-	int16_t height_scale = static_cast<int16_t>(floorf(32768.0f / 30.0f));
-	// Buffer used for unpacking various types into correct format for writing to stream.
-	uint8_t buffer[4];
-	out.write("TERRAGENTERRAIN ", 16); // First element of header.
-	// Write terrain size.
-	out.write("SIZE", 4);
-	unpack_16bit(static_cast<int16_t>(std::min(width, height) - 1), buffer);
-	out.write(reinterpret_cast<char*>(buffer), 2);
-	out.write("\0\0", 2);
-	// X dim.
-	out.write("XPTS", 4);
-	unpack_16bit(static_cast<int16_t>(width), buffer);
-	out.write(reinterpret_cast<char*>(buffer), 2);
-	out.write("\0\0", 2);
-	// Y dim
-	out.write("YPTS", 4);
-	unpack_16bit(static_cast<int16_t>(height), buffer);
-	out.write(reinterpret_cast<char*>(buffer), 2);
-	out.write("\0\0", 2);
-	// Write scale.
-	out.write("SCAL", 4);
-	// point-sampling scale is XYZ quantity, write same value three times.
-	unpack_float(15.0f, buffer);
-	out.write(reinterpret_cast<char*>(buffer), 4);
-	out.write(reinterpret_cast<char*>(buffer), 4);
-	out.write(reinterpret_cast<char*>(buffer), 4);
-	// Write height scale
-	out.write("ALTW", 4);
-	unpack_16bit(height_scale, buffer);
-	out.write(reinterpret_cast<char*>(buffer), 4);
-	out.write("\0\0", 2);
-	if (out.fail() || out.bad()) {
-		throw;
-	}
-
-	// Build and write each horizontal line to the file.
-	std::vector<int16_t> height_values = convertRawData_Ranged<int16_t>(rawData, 0.0f, 1000.0f);
-	for (size_t i = 0; i < height_values.size(); ++i) {
-		uint8_t buffer[2];
-		unpack_16bit(height_values[i], buffer);
-		out.write(reinterpret_cast<char*>(buffer), 2);
-	}
-	
-	out.write("EOF", 4);
-	// Close output file.
-	out.close();
-}
-
-void ImageWriter::SetRawData(const std::vector<float>& raw){
-	rawData = raw;
-}
-
-std::vector<float> ImageWriter::GetRawData() const{
-	return rawData;
-}
-
-void ImageWriter::WriteBMP_Header(std::ofstream & output_stream) const{
-	// TODO: Implement this. Need to do some more checks on insuring 4-byte alignment and correct sizing, somehow.
 }

--- a/cpp/image/Image.h
+++ b/cpp/image/Image.h
@@ -14,41 +14,48 @@
 
 */
 
-class ImageWriter {
-public:
+namespace cnoise {
 
-	// Initializes image and allocates space in vector used to hold raw data.
-	ImageWriter(int width, int height);
+	namespace img {
 
-	void FreeMemory();
+		class ImageWriter {
+		public:
 
-	// Writes data contained in this image to file with given name.
-	void WriteBMP(const char* filename);
+			// Initializes image and allocates space in vector used to hold raw data.
+			ImageWriter(int width, int height);
 
-	// Writes data contained in this image to PNG. Compression level set by
-	// second parameter, but is optional. Defaults to uncompressed.
-	void WritePNG(const char* filename, int compression_level = 0);
+			void FreeMemory();
 
-	void WriteTER(const char * filename);
+			// Writes data contained in this image to file with given name.
+			void WriteBMP(const char* filename);
 
-	// Sets rawData
-	void SetRawData(const std::vector<float>& raw);
+			// Writes data contained in this image to PNG. Compression level set by
+			// second parameter, but is optional. Defaults to uncompressed.
+			void WritePNG(const char* filename, int compression_level = 0);
 
-	// Gets rawData
-	std::vector<float> GetRawData() const;
+			void WriteTER(const char * filename);
 
-private:
-	// Holds raw data grabbed from one of the noise modules.
-	std::vector<float> rawData;
+			// Sets rawData
+			void SetRawData(const std::vector<float>& raw);
 
-	// Holds pixel data converted from rawData.
-	std::vector<unsigned char> pixelData;
+			// Gets rawData
+			std::vector<float> GetRawData() const;
 
-	// Dimensions of this image
-	int width, height;
+		private:
+			// Holds raw data grabbed from one of the noise modules.
+			std::vector<float> rawData;
 
-	// Writes BMP header.
-	void WriteBMP_Header(std::ofstream& output_stream) const;
-};
+			// Holds pixel data converted from rawData.
+			std::vector<unsigned char> pixelData;
+
+			// Dimensions of this image
+			int width, height;
+
+			// Writes BMP header.
+			void WriteBMP_Header(std::ofstream& output_stream) const;
+		};
+
+	}
+}
 
 #endif // !IMAGE_H

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -6,7 +6,7 @@
 #include "modules\generators\FBM.h"
 #include "modules\modifiers\Select.h"
 #include "modules\generators\DecarpientierSwiss.h"
-using namespace noise::module;
+using namespace cnoise::generators;
 
 int main() {
 	static int img_size = 8192;

--- a/cpp/modules/Base.cpp
+++ b/cpp/modules/Base.cpp
@@ -3,7 +3,7 @@
 #include "../image/Image.h"
 
 
-namespace noise {
+namespace cnoise {
 
 	namespace module {
 
@@ -53,20 +53,31 @@ namespace noise {
 			cudaAssert(err);
 		}
 
-		void Module::ConnectModule(Module &other) {
-			// Copy preceding source modules from "other"
-			sourceModules = other.sourceModules;
-			// Add other to the source modules.
-			sourceModules.push_back(&other);
+		void Module::ConnectModule(Module* other) {
+			if (sourceModules.size() < GetSourceModuleCount() - 1) {
+				sourceModules.push_back(std::shared_ptr<Module>(other));
+			}
+		}
+
+		void Module::ConnectModule(std::shared_ptr<Module>& other) {
+			if (sourceModules.size() < GetSourceModuleCount() - 1) {
+				sourceModules.push_back(other);
+			}
+		}
+
+		void Module::ConnectModule(Module& other) {
+			if (sourceModules.size() < GetSourceModuleCount() - 1) {
+				sourceModules.push_back(std::shared_ptr<Module>(&other));
+			}
 		}
 
 		cudaSurfaceObject_t Module::GetData() const{
 			return output;
 		}
 
-		Module* Module::GetModule(size_t idx) const {
+		Module& Module::GetModule(size_t idx) const {
 			// .at(idx) has bounds checking in debug modes, iirc.
-			return sourceModules.at(idx);
+			return *sourceModules.at(idx);
 		}
 
 		std::vector<float> Module::GetGPUData() const{

--- a/cpp/modules/Base.h
+++ b/cpp/modules/Base.h
@@ -14,9 +14,7 @@
 	commands to create the final object.
 
 */
-namespace noise {
-
-	namespace module {
+namespace cnoise {
 
 		class Module {
 			// Delete copy ctor and operator
@@ -33,8 +31,13 @@ namespace noise {
 			// Destructor calls functions to clear CUDA objects/data
 			virtual ~Module();
 
+			// Conversion
+			
+			
 			// Connects this module to another source module
+			virtual void ConnectModule(Module* other);
 			virtual void ConnectModule(Module& other);
+			virtual void ConnectModule(std::shared_ptr<Module>& other);
 
 			// Generates data and stores it in this object
 			virtual void Generate() = 0;
@@ -43,7 +46,7 @@ namespace noise {
 			virtual cudaSurfaceObject_t GetData() const;
 
 			// Gets reference to module at given index in this modules "sourceModules" container
-			virtual Module* GetModule(size_t idx) const;
+			virtual Module& GetModule(size_t idx) const;
 
 			// Get number of source modules connected to this object.
 			virtual size_t GetSourceModuleCount() const = 0;
@@ -77,31 +80,33 @@ namespace noise {
 			// of the vector being the module immediately before 
 			// this one, and the front of the vector being the initial
 			// module.
-			std::vector<Module*> sourceModules;
+			std::vector<std::shared_ptr<Module>> sourceModules;
 		};
 
-		// Config struct for noise generators.
-		struct noiseCfg {
+		namespace generators {
 
-			// Seed for the noise generator
-			int Seed;
-			// Frequency of the noise
-			float Frequency;
-			// Lacunarity controls amplitude of the noise, effectively
-			float Lacunarity;
-			// Controls how many octaves to use during octaved noise generation
-			int Octaves;
-			// Persistence controls how the amplitude of successive octaves decreases.
-			float Persistence;
-			
-			noiseCfg(int s, float f, float l, int o, float p) : Seed(s), Frequency(f), Lacunarity(l), Octaves(o), Persistence(p) {}
+			// Config struct for noise generators.
+			struct noiseCfg {
 
-			noiseCfg() = default;
-			~noiseCfg() = default;
+				// Seed for the noise generator
+				int Seed;
+				// Frequency of the noise
+				float Frequency;
+				// Lacunarity controls amplitude of the noise, effectively
+				float Lacunarity;
+				// Controls how many octaves to use during octaved noise generation
+				int Octaves;
+				// Persistence controls how the amplitude of successive octaves decreases.
+				float Persistence;
 
-		};
+				noiseCfg(int s, float f, float l, int o, float p) : Seed(s), Frequency(f), Lacunarity(l), Octaves(o), Persistence(p) {}
 
-	}
+				noiseCfg() = default;
+				~noiseCfg() = default;
+
+			};
+
+		}
 }
 
 

--- a/cpp/modules/combiners/Select.cpp
+++ b/cpp/modules/combiners/Select.cpp
@@ -1,13 +1,13 @@
 #include "Select.h"
 #include "..\cuda\modifiers\select.cuh"
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace combiners {
 
 		Select::Select(int width, int height, float low_value, float high_value, float _falloff, Module* selector, Module* subject0, Module* subject1) : Module(width, height), lowThreshold(low_value), highThreshold(high_value), falloff(_falloff)  {
-			sourceModules.push_back(selector);
-			sourceModules.push_back(subject0);
-			sourceModules.push_back(subject1);
+			sourceModules[0] = std::shared_ptr<Module>(selector);
+			sourceModules[1] = std::shared_ptr<Module>(subject0);
+			sourceModules[2] = std::shared_ptr<Module>(subject1);
 		}
 
 		void Select::SetSubject(size_t idx, Module* subject){
@@ -16,27 +16,26 @@ namespace noise {
 				throw("Invalid index supplied");
 			}
 			else {
-				sourceModules[idx] = subject;
+				sourceModules[idx] = std::shared_ptr<Module>(subject);
 			}
 		}
 
 		void Select::SetSelector(Module* selector){
-			sourceModules[0] = selector;
+			sourceModules[0] = std::shared_ptr<Module>(selector);
 		}
 
 		void Select::Generate() {
-			if (!sourceModules[0]->Generated) {
-				sourceModules[0]->Generate();
-			}
-			if (!sourceModules[1]->Generated) {
-				sourceModules[1]->Generate();
-			}
-			if (!sourceModules[2]->Generated) {
-				sourceModules[1]->Generate();
+
+			// Make sure modules are connected
+			if (sourceModules[0] == nullptr || sourceModules[1] == nullptr || sourceModules[2] == nullptr) {
+				throw;
 			}
 
-			if (sourceModules[0] == nullptr || sourceModules[1] == nullptr || sourceModules[2] == nullptr) {
-				return;
+			// Make sure all source modules are generated.
+			for (const auto& module : sourceModules) {
+				if (!module->Generated) {
+					module->Generate();
+				}
 			}
 
 			SelectLauncher(output, sourceModules[0]->output, sourceModules[1]->output, sourceModules[2]->output, dims.first, dims.second, highThreshold, lowThreshold, falloff);
@@ -47,8 +46,8 @@ namespace noise {
 			highThreshold = _high;
 		}
 
-		void Select::SetLowThreshold(float _low)
-		{
+		void Select::SetLowThreshold(float _low){
+			lowThreshold = _low;
 		}
 
 		float Select::GetHighTreshold() const{

--- a/cpp/modules/combiners/Select.h
+++ b/cpp/modules/combiners/Select.h
@@ -3,8 +3,9 @@
 #define SELECT_H
 #include "..\Base.h"
 
-namespace noise {
-	namespace module {
+namespace cnoise {
+
+	namespace combiners {
 
 		/*
 

--- a/cpp/modules/generators/Billow.cpp
+++ b/cpp/modules/generators/Billow.cpp
@@ -3,18 +3,20 @@
 // Include cuda modules
 #include "..\cuda\generators\billow.cuh"
 
-namespace noise {
-	namespace module {
+namespace cnoise {
 
-		Billow2D::Billow2D(int width, int height, noise_t noise_type, float x, float y, int seed, float freq, float lacun, int octaves, float persist) : Module(width, height), Attributes(seed, freq, lacun, octaves, persist), Origin(x, y), NoiseType(noise_type) {}
+		namespace generators {
 
-		size_t Billow2D::GetSourceModuleCount() const {
-			return 0;
+			Billow2D::Billow2D(int width, int height, noise_t noise_type, float x, float y, int seed, float freq, float lacun, int octaves, float persist) : Module(width, height), Attributes(seed, freq, lacun, octaves, persist), Origin(x, y), NoiseType(noise_type) {}
+
+			size_t Billow2D::GetSourceModuleCount() const {
+				return 0;
+			}
+
+			void Billow2D::Generate() {
+				BillowLauncher(output, dims.first, dims.second, NoiseType, make_float2(Origin.first, Origin.second), Attributes.Frequency, Attributes.Lacunarity, Attributes.Persistence, Attributes.Seed, Attributes.Octaves);
+				Generated = true;
+			}
+
 		}
-
-		void Billow2D::Generate(){
-			BillowLauncher(output, dims.first, dims.second, NoiseType, make_float2(Origin.first, Origin.second), Attributes.Frequency, Attributes.Lacunarity, Attributes.Persistence, Attributes.Seed, Attributes.Octaves);
-			Generated = true;
-		}
-	}
 }

--- a/cpp/modules/generators/Billow.h
+++ b/cpp/modules/generators/Billow.h
@@ -3,47 +3,49 @@
 #define BILLOW_H
 #include "..\Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+		namespace generators {
 
-		// Default parameters
-		constexpr float DEFAULT_BILLOW_FREQUENCY = 0.25f;
-		constexpr float DEFAULT_BILLOW_LACUNARITY = 2.0f;
-		constexpr int DEFAULT_BILLOW_OCTAVES = 6;
-		constexpr float DEFAULT_BILLOW_PERSISTENCE = 0.50f;
-		constexpr int DEFAULT_BILLOW_SEED = 0;
+			// Default parameters
+			constexpr float DEFAULT_BILLOW_FREQUENCY = 0.25f;
+			constexpr float DEFAULT_BILLOW_LACUNARITY = 2.0f;
+			constexpr int DEFAULT_BILLOW_OCTAVES = 6;
+			constexpr float DEFAULT_BILLOW_PERSISTENCE = 0.50f;
+			constexpr int DEFAULT_BILLOW_SEED = 0;
 
-		// Maximum octave level to allow
-		constexpr int BILLOW_MAX_OCTAVES = 24;
+			// Maximum octave level to allow
+			constexpr int BILLOW_MAX_OCTAVES = 24;
 
 
-		class Billow2D : public Module{
-		public:
+			class Billow2D : public Module {
+			public:
 
-			// Width + height specify output texture size.
-			// Seed defines a value to seed the generator with
-			// X & Y define the origin of the noise generator
-			Billow2D(int width, int height, noise_t noise_type = noise_t::PERLIN, float x = 0.0f, float y = 0.0f, int seed = DEFAULT_BILLOW_SEED, float freq = DEFAULT_BILLOW_FREQUENCY, float lacun = DEFAULT_BILLOW_LACUNARITY,
-				int octaves = DEFAULT_BILLOW_OCTAVES, float persist = DEFAULT_BILLOW_PERSISTENCE);
+				// Width + height specify output texture size.
+				// Seed defines a value to seed the generator with
+				// X & Y define the origin of the noise generator
+				Billow2D(int width, int height, noise_t noise_type = noise_t::PERLIN, float x = 0.0f, float y = 0.0f, int seed = DEFAULT_BILLOW_SEED, float freq = DEFAULT_BILLOW_FREQUENCY, float lacun = DEFAULT_BILLOW_LACUNARITY,
+					int octaves = DEFAULT_BILLOW_OCTAVES, float persist = DEFAULT_BILLOW_PERSISTENCE);
 
-			// Get source module count: must be 0, this is a generator and can't have preceding modules.
-			virtual size_t GetSourceModuleCount() const override;
+				// Get source module count: must be 0, this is a generator and can't have preceding modules.
+				virtual size_t GetSourceModuleCount() const override;
 
-			// Launches the kernel and fills this object's surface object with the relevant data.
-			virtual void Generate() override;
+				// Launches the kernel and fills this object's surface object with the relevant data.
+				virtual void Generate() override;
 
-			// Origin of this noise generator. Keep the seed constant and change this for 
-			// continuous "tileable" noise
-			std::pair<float, float> Origin;
+				// Origin of this noise generator. Keep the seed constant and change this for 
+				// continuous "tileable" noise
+				std::pair<float, float> Origin;
 
-			// Configuration attributes.
-			noiseCfg Attributes;
+				// Configuration attributes.
+				noiseCfg Attributes;
 
-			noise_t NoiseType;
+				noise_t NoiseType;
 
-		};
-	}
+			};
+
+		}
+
 }
 
 

--- a/cpp/modules/generators/DecarpientierSwiss.cpp
+++ b/cpp/modules/generators/DecarpientierSwiss.cpp
@@ -1,13 +1,14 @@
 #include "DecarpientierSwiss.h"
 #include "../cuda/generators/decarpientier_swiss.cuh"
 
-noise::module::DecarpientierSwiss::DecarpientierSwiss(int width, int height, noise_t noise_type, float x, float y, int seed, float freq, float lacun,
+noise::generators::DecarpientierSwiss::DecarpientierSwiss(int width, int height, noise_t noise_type, float x, float y, int seed, float freq, float lacun,
 	int octaves, float persist) : Module(width, height), Attributes(seed, freq, lacun, octaves, persist), Origin(x, y), NoiseType(noise_type){}
 
-size_t noise::module::DecarpientierSwiss::GetSourceModuleCount() const{
+size_t noise::generators::DecarpientierSwiss::GetSourceModuleCount() const{
 	return 0;
 }
 
-void noise::module::DecarpientierSwiss::Generate(){
+void noise::generators::DecarpientierSwiss::Generate(){
 	DecarpientierSwissLauncher(output, dims.first, dims.second, NoiseType, make_float2(Origin.first, Origin.second), Attributes.Frequency, Attributes.Lacunarity, Attributes.Persistence, Attributes.Seed, Attributes.Octaves);
+	Generated = true;
 }

--- a/cpp/modules/generators/DecarpientierSwiss.h
+++ b/cpp/modules/generators/DecarpientierSwiss.h
@@ -3,9 +3,9 @@
 #define DECARPIENTIER_SWISS_H
 #include "../Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace generators {
 
 		// Default parameters
 		constexpr float DEFAULT_DC_SWISS_FREQUENCY = 0.25f;

--- a/cpp/modules/generators/FBM.cpp
+++ b/cpp/modules/generators/FBM.cpp
@@ -1,9 +1,9 @@
 #include "FBM.h"
 #include "..\cuda\generators\FBM.cuh"
 #include "..\cuda\cuda_assert.h"
-namespace noise {
+namespace cnoise {
 	
-	namespace module {
+	namespace generators {
 
 		// Pass width and height to base class ctor, initialize configuration struct, initialize origin (using initializer list)
 		FBM2D::FBM2D(int width, int height, noise_t noise_type, int x, int y, int seed, float freq, float lacun, int octaves, float persist) : Module(width, height), 

--- a/cpp/modules/generators/FBM.h
+++ b/cpp/modules/generators/FBM.h
@@ -13,9 +13,9 @@
 	tables and the like. Without these, we have to use costly/slow array lookups.
 
 */
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace generators {
 
 		// Default parameters
 		constexpr float DEFAULT_FBM_FREQUENCY = 1.0f;

--- a/cpp/modules/generators/RidgedMulti.cpp
+++ b/cpp/modules/generators/RidgedMulti.cpp
@@ -1,8 +1,8 @@
 #include "RidgedMulti.h"
 #include "../cuda/generators/ridged_multi.cuh"
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace generators {
 
 
 		RidgedMulti::RidgedMulti(int width, int height, noise_t noise_type, float x, float y, int seed, float freq, float lacun, int octaves, float persist) : Module(width, height),

--- a/cpp/modules/generators/RidgedMulti.h
+++ b/cpp/modules/generators/RidgedMulti.h
@@ -3,9 +3,9 @@
 #define RIDGED_MULTI_H
 #include "../Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace generators {
 
 		// Default parameters
 		constexpr float DEFAULT_RIDGED_FREQUENCY = 1.0f;

--- a/cpp/modules/generators/Voronoi.cpp
+++ b/cpp/modules/generators/Voronoi.cpp
@@ -1,9 +1,9 @@
 #include "Voronoi.h"
 
 
-namespace noise {
+namespace cnoise {
 	
-	namespace module {
+	namespace generators {
 
 		Voronoi::Voronoi(int width, int height, voronoi_distance_t cell_dist_func, voronoi_return_t return_t, float freq, float displ, int seed) : Module(width, height), Displacement(displ), Frequency(freq), CellDistanceType(cell_dist_func), ReturnDataType(return_t) {}
 

--- a/cpp/modules/generators/Voronoi.h
+++ b/cpp/modules/generators/Voronoi.h
@@ -4,9 +4,9 @@
 #include "../Base.h"
 
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace generators {
 
 
 		constexpr float DEFAULT_VORONOI_DISPLACEMENT = 1.0f;

--- a/cpp/modules/modifiers/Abs.cpp
+++ b/cpp/modules/modifiers/Abs.cpp
@@ -1,0 +1,20 @@
+#include "Abs.h"
+#include "../cuda/modifiers/abs.cuh"
+
+cnoise::modifiers::Abs::Abs(const size_t width, const size_t height, Module * previous) : Module(width, height) {
+}
+
+size_t cnoise::modifiers::Abs::GetSourceModuleCount() const{
+	return 1;
+}
+
+void cnoise::modifiers::Abs::Generate() {
+	if (sourceModules.front() == nullptr) {
+		throw;
+	}
+	if (!sourceModules.front()->Generated) {
+		sourceModules.front()->Generate();
+	}
+	absLauncher(output, sourceModules.front()->output, dims.first, dims.second);
+	Generated = true;
+}

--- a/cpp/modules/modifiers/Abs.h
+++ b/cpp/modules/modifiers/Abs.h
@@ -3,9 +3,9 @@
 #define ABS_H
 #include "../Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace modifiers {
 
 		class Abs : public Module {
 		public:
@@ -13,6 +13,8 @@ namespace noise {
 			Abs(const size_t width, const size_t height, Module* previous);
 
 			virtual size_t GetSourceModuleCount() const override;
+
+			void Generate() override;
 
 		};
 

--- a/cpp/modules/modifiers/Add.cpp
+++ b/cpp/modules/modifiers/Add.cpp
@@ -1,40 +1,31 @@
 #include "Add.h"
 #include "../cuda/modifiers/add.cuh"
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace modifiers {
 
-		Add::Add(int width, int height, float add_value, Module* source) : Module(width, height), addValue(add_value) {
-			sourceModules.push_back(source);
+		Add::Add(int width, int height, float add_value, Module* source) : Module(width, height) {
+			sourceModules.front() = std::shared_ptr<Module>(source);
 		}
 
 		void Add::Generate(){
-			// Check source modules container.
-			if (sourceModules.empty() || sourceModules.front() == nullptr) {
-				std::cerr << "Did you forget to attach a source module(s) to your add module?" << std::endl;
-				throw("No source module(s) for Add module, abort");
-			}
-
-			// Make sure all modules in source modules container are generated.
+			// Make sure all modules in source modules container are generated. (and that there are no null module connections)
 			for (const auto& module : sourceModules) {
+				if (module == nullptr) {
+					std::cerr << "Did you forget to attach a source module(s) to your add module?" << std::endl;
+					throw("No source module(s) for Add module, abort");
+				}
 				if (!module->Generated) {
 					module->Generate();
 				}
 			}
 			
-			AddLauncher(output, sourceModules[0]->output, dims.first, dims.second, addValue);
+			AddLauncher(output, sourceModules[0]->output, sourceModules[1]->output, dims.first, dims.second);
+			Generated = true;
 		}
 
 		size_t Add::GetSourceModuleCount() const{
-			return sourceModules.size();
-		}
-
-		void Add::SetAddValue(float val) {
-			addValue = val;
-		}
-
-		float Add::GetAddValue() const {
-			return addValue;
+			return 2;
 		}
 
 	}

--- a/cpp/modules/modifiers/Add.h
+++ b/cpp/modules/modifiers/Add.h
@@ -3,9 +3,9 @@
 #define ADD_H
 #include "../Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace modifiers {
 
 		class Add : public Module {
 		public:
@@ -16,15 +16,8 @@ namespace noise {
 
 			virtual size_t GetSourceModuleCount() const override;
 
-			// Set value to add to source module
-			void SetAddValue(float val);
-
-			// Get add value
-			float GetAddValue() const;
-
 		private: 
 
-			float addValue;
 		};
 
 	}

--- a/cpp/modules/modifiers/Curve.cpp
+++ b/cpp/modules/modifiers/Curve.cpp
@@ -1,7 +1,8 @@
 #include "Curve.h"
 #include "../cuda/modifiers/curve.cuh"
-namespace noise {
-	namespace module {
+namespace cnoise {
+
+	namespace modifiers {
 
 		Curve::Curve(int width, int height) : Module(width, height) {}
 
@@ -29,9 +30,11 @@ namespace noise {
 				std::cerr << "Did you forget to attach a module for curving to this curve module?" << std::endl;
 				throw("NOISE::MODULES::MODIFIER::CURVE:L32: No source module connected.");
 			}
+			
 			if (!sourceModules.front()->Generated) {
 				sourceModules.front()->Generate();
 			}
+			
 			CurveLauncher(output, sourceModules.front()->output, dims.first, dims.second, controlPoints);
 			Generated = true;
 		}

--- a/cpp/modules/modifiers/Curve.h
+++ b/cpp/modules/modifiers/Curve.h
@@ -16,9 +16,9 @@
 
 */
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace modifiers {
 
 		class Curve : public Module {
 		public:

--- a/cpp/modules/modifiers/Power.h
+++ b/cpp/modules/modifiers/Power.h
@@ -1,0 +1,16 @@
+#pragma once
+#ifndef POWER_H
+#define POWER_H
+#include "../Base.h"
+
+namespace cnoise {
+
+	namespace modifiers {
+
+
+
+	}
+
+}
+
+#endif // !POWER_H

--- a/cpp/modules/modifiers/ScaleBias.cpp
+++ b/cpp/modules/modifiers/ScaleBias.cpp
@@ -1,0 +1,35 @@
+#include "ScaleBias.h"
+// #include "../cuda/modifiers/scalebias.cuh"
+
+cnoise::modifiers::ScaleBias::ScaleBias(const size_t width, const size_t height, const float _scale, const float _bias) : Module(width, height), scale(_scale), bias(_bias){}
+
+void cnoise::modifiers::ScaleBias::SetBias(const float _bias){
+	bias = _bias;
+}
+
+void cnoise::modifiers::ScaleBias::SetScale(const float _scale){
+	scale = _scale;
+}
+
+float cnoise::modifiers::ScaleBias::GetBias() const{
+	return bias;
+}
+
+float cnoise::modifiers::ScaleBias::GetScale() const{
+	return scale;
+}
+
+size_t cnoise::modifiers::ScaleBias::GetSourceModuleCount() const{
+	return 1;
+}
+
+void cnoise::modifiers::ScaleBias::Generate(){
+	if (sourceModules.front() == nullptr) {
+		throw;
+	}
+	if (!sourceModules.front()->Generated) {
+		sourceModules.front()->Generate();
+	}
+
+	Generated = true;
+}

--- a/cpp/modules/modifiers/ScaleBias.h
+++ b/cpp/modules/modifiers/ScaleBias.h
@@ -1,0 +1,36 @@
+#pragma once
+#ifndef SCALE_BIAS_H
+#define SCALE_BIAS_H
+#include "../Base.h"
+
+namespace cnoise {
+
+	namespace modifiers {
+
+		class ScaleBias : public Module {
+		public:
+
+			ScaleBias(const size_t width, const size_t height, const float scale, const float bias);
+
+			void SetBias(const float bias);
+
+			void SetScale(const float scale);
+
+			float GetBias() const;
+
+			float GetScale() const;
+
+			virtual size_t GetSourceModuleCount() const override;
+
+			void Generate() override;
+
+		private:
+
+			float bias, scale;
+
+		};
+
+	}
+
+}
+#endif // !SCALE_BIAS_H

--- a/cpp/modules/modifiers/Turbulence.cpp
+++ b/cpp/modules/modifiers/Turbulence.cpp
@@ -1,11 +1,11 @@
 #include "Turbulence.h"
 #include "../cuda/modifiers/turbulence.cuh"
-namespace noise {
+namespace cnoise {
 	
-	namespace module {
+	namespace modifiers {
 
 		Turbulence::Turbulence(int width, int height, noise_t noise_type, Module* prev, int _roughness, int _seed, float _strength) : Module(width, height), roughness(_roughness), seed(_seed), strength(_strength) {
-			sourceModules.push_back(prev);
+			ConnectModule(prev);
 		}
 
 		size_t Turbulence::GetSourceModuleCount() const{

--- a/cpp/modules/modifiers/Turbulence.h
+++ b/cpp/modules/modifiers/Turbulence.h
@@ -3,9 +3,9 @@
 #define TURBULENCE_H
 #include "../Base.h"
 
-namespace noise {
+namespace cnoise {
 
-	namespace module {
+	namespace modifiers {
 
 		constexpr int DEFAULT_TURBULENCE_ROUGHNESS = 3;
 		constexpr int DEFAULT_TURBULENCE_SEED = 0;

--- a/cuda/modifiers/Add.cu
+++ b/cuda/modifiers/Add.cu
@@ -1,6 +1,6 @@
 #include "Add.cuh"
 
-__global__ void AddKernel(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const int width, const int height, float add_value) {
+__global__ void AddKernel(cudaSurfaceObject_t output, cudaSurfaceObject_t input0, cudaSurfaceObject_t input1, const int width, const int height) {
 	// Get current pixel.
 	const int i = blockDim.x * blockIdx.x + threadIdx.x;
 	const int j = blockDim.y * blockIdx.y + threadIdx.y;
@@ -10,17 +10,18 @@ __global__ void AddKernel(cudaSurfaceObject_t output, cudaSurfaceObject_t input,
 	// Reading from a surface still requires the byte offset, so multiply the x coordinate by the size of a float in bytes.
 	// surf2Dread also writes the value at the point to a pre-existing variable, so declare soemthing like "prev" and pass
 	// it as a reference (&prev) to the surf2Dread function.
-	float prev;
-	surf2Dread(&prev, input, i * sizeof(float), j);
-
+	float prev0;
+	surf2Dread(&prev0, input0, i * sizeof(float), j);
+	float prev1;
+	surf2Dread(&prev1, input1, i * sizeof(float), j);
 	// Add value to prev.
-	prev += add_value;
+	float result = prev0 + prev1;
 
 	// Store value in destination surface.
-	surf2Dwrite(prev, output, i * sizeof(float), j);
+	surf2Dwrite(result, output, i * sizeof(float), j);
 }
 
-void AddLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const int width, const int height, float add_value){
+void AddLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input0, cudaSurfaceObject_t input1, const int width, const int height){
 #ifdef CUDA_KERNEL_TIMING
 	cudaEvent_t start, stop;
 	cudaEventCreate(&start);
@@ -30,10 +31,10 @@ void AddLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const in
 
 	// Setup dimensions of kernel launch using occupancy calculator.
 	int blockSize, minGridSize;
-	cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, AddKernel, 0, 0); //???
+	cudaOccupancyMaxPotentialBlockSize(&minGridSize, &blockSize, AddKernel, 0, 0);
 	dim3 block(blockSize, blockSize, 1);
 	dim3 grid((width - 1) / blockSize + 1, (height - 1) / blockSize + 1, 1);
-	AddKernel<<<grid, block>>>(output, input, width, height, add_value);
+	AddKernel<<<grid, block>>>(output, input0, input1, width, height);
 	// Check for succesfull kernel launch
 	cudaAssert(cudaGetLastError());
 	// Synchronize device

--- a/cuda/modifiers/Add.cuh
+++ b/cuda/modifiers/Add.cuh
@@ -2,6 +2,6 @@
 #define ADD_CUH
 #include "../common/CUDA_Include.h"
 
-void AddLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const int width, const int height, float add_value);
+void AddLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input0, cudaSurfaceObject_t input1, const int width, const int height);
 
 #endif // !ADD_CUH

--- a/cuda/modifiers/abs.cu
+++ b/cuda/modifiers/abs.cu
@@ -1,4 +1,5 @@
 #include "abs.cuh"
+#include "..\..\cpp\modules\modifiers\Abs.h"
 
 __global__ void absKernel(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const int width, const int height) {
 	const int i = blockIdx.x * blockDim.x + threadIdx.x;

--- a/cuda/modifiers/multiply.cu
+++ b/cuda/modifiers/multiply.cu
@@ -15,8 +15,6 @@ __global__ void multiplyKernel(cudaSurfaceObject_t output, cudaSurfaceObject_t i
 	float final_value;
 	final_value = prev * factor;
 
-
-
 	surf2Dwrite(final_value, output, i * sizeof(float), j);
 
 }

--- a/cuda/modifiers/power.cuh
+++ b/cuda/modifiers/power.cuh
@@ -2,7 +2,7 @@
 #define POWER_CUH
 #include "../common/CUDA_Include.h"
 
-void powerLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input, const int width, const int height, int p);
+void powerLauncher(cudaSurfaceObject_t output, cudaSurfaceObject_t input0, cudaSurfaceObject_t input1, const int width, const int height);
 
 
 #endif 


### PR DESCRIPTION
…standing of libnoise/documentation meant we were using constant values, when these are usually designed to work between two seperate modules.